### PR TITLE
site, beginner テーマの ol > li 内に複数の p タグがある場合のレイアウト崩れを修正

### DIFF
--- a/themes/beginner/dest/bundle.css
+++ b/themes/beginner/dest/bundle.css
@@ -44,10 +44,6 @@ a {
   border: none;
 }
 
-::-moz-placeholder {
-  color: var(--color-gray70) !important;
-}
-
 ::placeholder {
   color: var(--color-gray70) !important;
 }
@@ -226,8 +222,7 @@ a {
 }
 .main-visual-slider .splide__slide picture,
 .main-visual-slider .splide__slide img {
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 .main-visual-slider .splide__toggle {
   display: flex;
@@ -410,9 +405,6 @@ a {
   text-decoration: none;
 }
 @media (hover: hover) {
-  .banner-link:-moz-any-link:hover .banner-img {
-    box-shadow: var(--box-shadow-hover);
-  }
   .banner-link:any-link:hover .banner-img {
     box-shadow: var(--box-shadow-hover);
   }
@@ -448,10 +440,6 @@ a {
   border-radius: var(--border-radius-md);
   transition: background-color 0.2s;
 }
-.button:-moz-any-link {
-  color: var(--color-white);
-  text-decoration: none;
-}
 .button:any-link {
   color: var(--color-white);
   text-decoration: none;
@@ -466,9 +454,6 @@ a {
 .button.is-bg-white-bordered {
   background: var(--color-white);
   border: var(--border-width-sm) solid var(--color-gray30);
-}
-.button.is-bg-white-bordered:-moz-any-link {
-  color: var(--color-text);
 }
 .button.is-bg-white-bordered, .button.is-bg-white-bordered:any-link {
   color: var(--color-text);
@@ -501,9 +486,6 @@ a {
   animation: fade-in 0.2s 1.2s 1 both;
 }
 @media (hover: hover) {
-  .button-view-all-articles:-moz-any-link:hover .button-view-all-articles-icon {
-    background-color: var(--color-icon-bg-hover);
-  }
   .button-view-all-articles:any-link:hover .button-view-all-articles-icon {
     background-color: var(--color-icon-bg-hover);
   }
@@ -530,8 +512,7 @@ a {
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .button-view-all-articles-icon svg path {
   stroke: currentcolor;
@@ -608,13 +589,6 @@ a {
   }
 }
 @media (hover: hover) and (min-width: 30rem) {
-  .card-link:-moz-any-link:hover {
-    /*
-      * sm幅以上でのみ、リンクホバー時に背景色が表示されるように設定しています。
-      * この背景色は、シャドウのようにコンテンツからはみ出して表示されます。
-      * sm幅未満では画面端に角丸背景色が接することで、視覚的バランスを損なうため適用していません。
-      */
-  }
   .card-link:any-link:hover {
     /*
       * sm幅以上でのみ、リンクホバー時に背景色が表示されるように設定しています。
@@ -622,22 +596,13 @@ a {
       * sm幅未満では画面端に角丸背景色が接することで、視覚的バランスを損なうため適用していません。
       */
   }
-  .card-link:-moz-any-link:hover::after {
-    background-color: var(--color-hover-bg-2nd);
-  }
   .card-link:any-link:hover::after {
     background-color: var(--color-hover-bg-2nd);
   }
 }
 @media (hover: hover) {
-  .card-link:-moz-any-link:hover .card-img {
-    transform: scale(1.2);
-  }
   .card-link:any-link:hover .card-img {
     transform: scale(1.2);
-  }
-  .card-link:-moz-any-link:hover .card-read-more-icon {
-    background-color: var(--color-icon-bg-hover);
   }
   .card-link:any-link:hover .card-read-more-icon {
     background-color: var(--color-icon-bg-hover);
@@ -679,8 +644,7 @@ a {
   width: 100%;
   height: auto;
   aspect-ratio: var(--card-img-aspect-ratio, 16/9);
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 /* 画像上に重ねて表示するラベル */
@@ -785,9 +749,9 @@ a {
   display: -webkit-box;
   margin: 0;
   overflow: hidden;
-  color: var(--color-text-2nd);
   -webkit-line-clamp: 4;
   line-clamp: 4;
+  color: var(--color-text-2nd);
   -webkit-box-orient: vertical;
 }
 
@@ -797,9 +761,9 @@ a {
   flex-wrap: wrap;
   gap: 0.25rem 1rem;
   align-items: flex-start;
+  padding-inline-start: 0;
   margin-top: 0;
   margin-bottom: 0;
-  padding-inline-start: 0;
   line-height: var(--line-height-none);
   list-style-type: none;
 }
@@ -880,8 +844,7 @@ a {
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .card-read-more-icon svg path {
   stroke: currentcolor;
@@ -918,9 +881,6 @@ a {
   border-bottom: var(--border-width-sm) dotted var(--color-white);
 }
 @media (hover: hover) {
-  .cta-visual a[href^="tel:"]:-moz-any-link:hover {
-    border-color: transparent;
-  }
   .cta-visual a[href^="tel:"]:any-link:hover {
     border-color: transparent;
   }
@@ -956,9 +916,9 @@ a {
   left: 50%;
   width: 12px;
   height: 10px;
-  clip-path: polygon(50% 100%, 0 0, 100% 0);
   content: "";
   background-color: var(--color-white);
+  clip-path: polygon(50% 100%, 0 0, 100% 0);
   transform: translateX(-50%);
 }
 
@@ -1104,8 +1064,8 @@ a {
   height: 2px;
   content: "";
   background: var(--color-primary);
-  transition: transform 0.2s;
   transform: scaleX(0);
+  transition: transform 0.2s;
 }
 .global-nav-link:hover {
   text-decoration: none;
@@ -1408,8 +1368,8 @@ a {
           mask-image: url(data:image/svg+xml;base64,PHN2ZyBhcmlhLWhpZGRlbj0idHJ1ZSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTEwIDE4TDE2IDEyTDEwIDYiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPjwvc3ZnPgo=);
   -webkit-mask-size: contain;
           mask-size: contain;
-  transition: transform 0.3s ease;
   transform: rotate(90deg);
+  transition: transform 0.3s ease;
 }
 :where(.global-nav-mobile-item.level-1:has(.global-nav-mobile-group)) > .global-nav-mobile-link .icon-expand.is-close {
   transform: rotate(-90deg);
@@ -1461,9 +1421,9 @@ a {
   padding: 0;
   margin: 0;
   overflow: hidden;
+  list-style-type: "";
   border-radius: var(--border-radius-lg);
   box-shadow: var(--box-shadow);
-  list-style-type: "";
 }
 .js .headline-list.js-animation-row {
   opacity: 0;
@@ -1485,9 +1445,6 @@ a {
 @media (hover: hover) {
   .headline-link {
     transition: background-color 0.3s ease;
-  }
-  .headline-link:-moz-any-link:hover {
-    background-color: var(--color-hover-bg-2nd);
   }
   .headline-link:any-link:hover {
     background-color: var(--color-hover-bg-2nd);
@@ -1727,8 +1684,8 @@ a {
   margin: 0 0 0 1rem;
   font-size: 0.8rem;
   font-weight: normal;
-  color: var(--color-danger);
   vertical-align: middle;
+  color: var(--color-danger);
   background: var(--color-danger-light);
   border-radius: var(--border-radius-sm);
 }
@@ -1738,8 +1695,8 @@ a {
   margin: 0 0 0 1rem;
   font-size: 0.8rem;
   font-weight: normal;
-  color: var(--color-text);
   vertical-align: middle;
+  color: var(--color-text);
   background: var(--color-gray10);
   border-radius: var(--border-radius-sm);
 }
@@ -1926,7 +1883,6 @@ a {
     padding: 0.75rem;
   }
   .form-group select {
-    width: -moz-fit-content;
     width: fit-content;
   }
 }
@@ -2048,8 +2004,8 @@ a {
   display: none;
 }
 .form-group .valid-mark.valid {
-  display: inline;
   float: right;
+  display: inline;
   color: #5cb85c;
 }
 .form-group .invalid {
@@ -2227,8 +2183,7 @@ a {
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .local-nav-link-icon svg path {
   stroke: currentcolor;
@@ -2284,8 +2239,7 @@ a {
 .main-visual .main-visual-bg img {
   width: 100%;
   height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 .main-visual .main-visual-box {
   position: absolute;
@@ -2423,13 +2377,6 @@ a {
   }
 }
 @media (hover: hover) and (min-width: 30rem) {
-  .media-item-link:-moz-any-link:hover {
-    /*
-    * sm幅以上でのみ、リンクホバー時に背景色が表示されるように設定しています。
-    * この背景色は、シャドウのようにコンテンツからはみ出して表示されます。
-    * sm幅未満では画面端に角丸背景色が接することで、視覚的バランスを損なうため適用していません。
-    */
-  }
   .media-item-link:any-link:hover {
     /*
     * sm幅以上でのみ、リンクホバー時に背景色が表示されるように設定しています。
@@ -2437,22 +2384,13 @@ a {
     * sm幅未満では画面端に角丸背景色が接することで、視覚的バランスを損なうため適用していません。
     */
   }
-  .media-item-link:-moz-any-link:hover::after {
-    background-color: var(--color-hover-bg-2nd);
-  }
   .media-item-link:any-link:hover::after {
     background-color: var(--color-hover-bg-2nd);
   }
 }
 @media (hover: hover) {
-  .media-item-link:-moz-any-link:hover .media-item-img {
-    transform: scale(1.2);
-  }
   .media-item-link:any-link:hover .media-item-img {
     transform: scale(1.2);
-  }
-  .media-item-link:-moz-any-link:hover .media-item-read-more-icon {
-    background-color: var(--color-icon-bg-hover);
   }
   .media-item-link:any-link:hover .media-item-read-more-icon {
     background-color: var(--color-icon-bg-hover);
@@ -2506,8 +2444,7 @@ a {
   display: block;
   width: 100%;
   height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 /* テキスト類全体の縦積みレイアウト */
@@ -2561,11 +2498,11 @@ a {
   display: -webkit-box;
   margin: 0;
   overflow: hidden;
-  font-size: 1rem;
-  color: var(--color-text-2nd);
   text-overflow: ellipsis;
   -webkit-line-clamp: 2;
   line-clamp: 2;
+  font-size: 1rem;
+  color: var(--color-text-2nd);
   -webkit-box-orient: vertical;
 }
 
@@ -2575,9 +2512,9 @@ a {
   flex-wrap: wrap;
   gap: 0.25rem 1rem;
   align-items: flex-start;
+  padding-inline-start: 0;
   margin-top: 0;
   margin-bottom: 0;
-  padding-inline-start: 0;
   line-height: var(--line-height-none);
   list-style-type: "";
 }
@@ -2622,8 +2559,7 @@ a {
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .media-item-read-more-icon svg path {
   stroke: currentcolor;
@@ -2696,7 +2632,6 @@ a {
 }
 
 .page-title-text-wrap {
-  width: -moz-fit-content;
   width: fit-content;
   margin-right: auto;
   text-align: left;
@@ -2820,15 +2755,8 @@ a {
   color: inherit;
 }
 @media (hover: hover) {
-  .pager-link:-moz-any-link {
-    -moz-transition: background-color 0.3s ease;
-    transition: background-color 0.3s ease;
-  }
   .pager-link:any-link {
     transition: background-color 0.3s ease;
-  }
-  .pager-link:-moz-any-link:hover {
-    background-color: var(--color-hover-bg);
   }
   .pager-link:any-link:hover {
     background-color: var(--color-hover-bg);
@@ -2870,24 +2798,16 @@ a {
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .pager-simple-arrow-icon svg path,
 .serial-nav-arrow-icon svg path {
   stroke: currentcolor;
 }
 @media (hover: hover) {
-  a:-moz-any-link .pager-simple-arrow-icon, a:-moz-any-link .serial-nav-arrow-icon {
-    -moz-transition: background-color 0.3s ease;
-    transition: background-color 0.3s ease;
-  }
   a:any-link .pager-simple-arrow-icon,
   a:any-link .serial-nav-arrow-icon {
     transition: background-color 0.3s ease;
-  }
-  a:-moz-any-link:hover .pager-simple-arrow-icon, a:-moz-any-link:hover .serial-nav-arrow-icon {
-    background-color: var(--color-icon-bg-hover);
   }
   a:any-link:hover .pager-simple-arrow-icon,
   a:any-link:hover .serial-nav-arrow-icon {
@@ -2932,9 +2852,6 @@ a {
 @media (hover: hover) {
   .pager-simple-link {
     transition: background-color 0.3s ease;
-  }
-  .pager-simple-link:-moz-any-link:hover {
-    background-color: var(--color-hover-bg-2nd);
   }
   .pager-simple-link:any-link:hover {
     background-color: var(--color-hover-bg-2nd);
@@ -3025,9 +2942,6 @@ a {
   .serial-nav-item-next a {
     transition: background-color 0.3s ease;
   }
-  .serial-nav-item-prev a:-moz-any-link:hover, .serial-nav-item-next a:-moz-any-link:hover {
-    background-color: var(--color-hover-bg-2nd);
-  }
   .serial-nav-item-prev a:any-link:hover,
   .serial-nav-item-next a:any-link:hover {
     background-color: var(--color-hover-bg-2nd);
@@ -3056,9 +2970,9 @@ a {
   width: 100%;
   min-width: 0;
   overflow: hidden;
+  text-overflow: ellipsis;
   line-height: var(--line-height-base);
   color: var(--color-text);
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -3125,9 +3039,7 @@ a {
   height: 3rem;
   padding: 0.75rem 1rem;
   font-size: 1rem;
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
+  appearance: none;
   background: var(--color-white);
   border: var(--border-width-sm) solid var(--color-gray30);
   border-radius: var(--border-radius-md);
@@ -3138,9 +3050,9 @@ a {
   border-color: var(--color-gray50);
 }
 .form-search input.form-search-input:focus {
+  outline: none;
   background: var(--color-white);
   border-color: #137af3;
-  outline: none;
   box-shadow: var(--box-shadow-focus), 0 1px 1px 0 rgba(0, 0, 0, 0.1) inset;
 }
 .form-search .form-search-side-button {
@@ -3426,9 +3338,6 @@ a {
   .tag-filter-selected-item a {
     transition: opacity 0.3s ease;
   }
-  .tag-filter-selected-item a:-moz-any-link:hover {
-    opacity: 0.6;
-  }
   .tag-filter-selected-item a:any-link:hover {
     opacity: 0.6;
   }
@@ -3454,10 +3363,6 @@ a {
   font-size: 1rem;
   color: var(--color-text);
 }
-.tag-filter-choice-item a:-moz-any-link {
-  text-decoration: underline dotted 1px;
-  text-underline-offset: 3px;
-}
 .tag-filter-choice-item a:any-link {
   -webkit-text-decoration: underline dotted 1px;
           text-decoration: underline dotted 1px;
@@ -3467,9 +3372,6 @@ a {
   color: inherit;
 }
 @media (hover: hover) {
-  .tag-filter-choice-item a:-moz-any-link:hover {
-    text-decoration: none;
-  }
   .tag-filter-choice-item a:any-link:hover {
     text-decoration: none;
   }
@@ -3538,10 +3440,6 @@ a {
   text-decoration: none;
 }
 @media (hover: hover) {
-  .topicpath-link:-moz-any-link:hover {
-    text-decoration: underline dotted 1px;
-    text-underline-offset: 3px;
-  }
   .topicpath-link:any-link:hover {
     -webkit-text-decoration: underline dotted 1px;
             text-decoration: underline dotted 1px;
@@ -3635,9 +3533,6 @@ a {
   color: inherit;
 }
 @media (hover: hover) {
-  .paragraph a:-moz-any-link:hover {
-    border-bottom-color: transparent;
-  }
   .paragraph a:any-link:hover {
     border-bottom-color: transparent;
   }
@@ -3712,9 +3607,6 @@ a {
   color: var(--color-text);
 }
 @media (hover: hover) {
-  .entry-header-category-label:-moz-any-link:hover {
-    background-color: var(--color-hover-bg-2nd);
-  }
   .entry-header-category-label:any-link:hover {
     background-color: var(--color-hover-bg-2nd);
   }
@@ -3775,10 +3667,6 @@ a {
   font-size: 0.8rem;
   color: var(--color-text);
 }
-.entry-tag-item a:-moz-any-link {
-  text-decoration: underline dotted 1px;
-  text-underline-offset: 3px;
-}
 .entry-tag-item a:any-link {
   -webkit-text-decoration: underline dotted 1px;
           text-decoration: underline dotted 1px;
@@ -3788,9 +3676,6 @@ a {
   color: inherit;
 }
 @media (hover: hover) {
-  .entry-tag-item a:-moz-any-link:hover {
-    text-decoration: none;
-  }
   .entry-tag-item a:any-link:hover {
     text-decoration: none;
   }
@@ -3858,9 +3743,6 @@ a {
           mask-size: contain;
 }
 @media (hover: hover) {
-  .detail-panel a:-moz-any-link:hover {
-    text-decoration: none;
-  }
   .detail-panel a:any-link:hover {
     text-decoration: none;
   }
@@ -3986,9 +3868,6 @@ a {
   color: inherit;
 }
 @media (hover: hover) {
-  .section-horizontal-text a:-moz-any-link:hover {
-    border-bottom-color: transparent;
-  }
   .section-horizontal-text a:any-link:hover {
     border-bottom-color: transparent;
   }
@@ -4048,9 +3927,9 @@ a {
   background: var(--color-gray30);
 }
 .js .js-animation .section-vertical-header::after {
-  transition: 0.2s ease-out 0.5s;
   transform: scaleY(0);
   transform-origin: top;
+  transition: 0.2s ease-out 0.5s;
   will-change: transform, opacity;
 }
 .js .js-animation.is-show .section-vertical-header::after {
@@ -4161,14 +4040,8 @@ a {
 }
 
 @media (hover: hover) {
-  .summary-side-link:-moz-any-link:hover::after {
-    background-color: var(--color-hover-bg-2nd);
-  }
   .summary-side-link:any-link:hover::after {
     background-color: var(--color-hover-bg-2nd);
-  }
-  .summary-side-link:-moz-any-link:hover .summary-side-img {
-    transform: scale(1.2);
   }
   .summary-side-link:any-link:hover .summary-side-img {
     transform: scale(1.2);
@@ -4193,8 +4066,7 @@ a {
   display: block;
   width: 100%;
   height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   transition: transform 0.4s 0.2s ease-out;
   will-change: transform;
 }
@@ -4203,13 +4075,13 @@ a {
   display: -webkit-box;
   margin: 0;
   overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
   font-size: 1rem;
   font-weight: bold;
   line-height: var(--line-height-base);
   color: var(--color-text);
-  text-overflow: ellipsis;
-  -webkit-line-clamp: 3;
-  line-clamp: 3;
   -webkit-box-orient: vertical;
 }
 
@@ -4329,10 +4201,6 @@ a {
 }
 .footer-address-item a {
   color: inherit;
-}
-.footer-address-item a:-moz-any-link {
-  text-decoration: underline dotted 1px;
-  text-underline-offset: 3px;
 }
 .footer-address-item a:any-link {
   -webkit-text-decoration: underline dotted 1px;

--- a/themes/beginner/dest/editor.css
+++ b/themes/beginner/dest/editor.css
@@ -93,9 +93,6 @@
           mask-size: contain;
 }
 @media (hover: hover) {
-  .entry-style a:not(:where([class~=not-editor-style], [class~=not-editor-style] *, [class~=media-image-block], [class~=media-image-block] *, [class~=column-image], [class~=column-image] *, [class~=column-media], [class~=column-media] *, [class~=column-eximage], [class~=column-eximage] *)):-moz-any-link:hover {
-    text-decoration: none;
-  }
   .entry-style a:not(:where([class~=not-editor-style], [class~=not-editor-style] *, [class~=media-image-block], [class~=media-image-block] *, [class~=column-image], [class~=column-image] *, [class~=column-media], [class~=column-media] *, [class~=column-eximage], [class~=column-eximage] *)):any-link:hover {
     text-decoration: none;
   }
@@ -304,11 +301,10 @@
   counter-reset: order-list;
 }
 .entry-style ol:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) > li { /* ul 内に ol, ol 内に ul が入っていた時の対策として子セレクタで指定 */
+  clear: both;
   display: grid;
   grid-template-columns: subgrid; /* アイテム番号の幅を揃えるための設定 */
   grid-column: 1/-1; /* 列をまたいで全幅を確保 */
-  grid-auto-flow: column;
-  clear: both;
   font-size: 1rem;
   line-height: var(--line-height-base);
 }
@@ -317,7 +313,6 @@
 }
 .entry-style ol:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) > li::before {
   grid-column: 1;
-  padding-top: 1.4px; /* 番号位置の微調整 */
   font-weight: bold;
   color: var(--color-text-2nd);
   word-break: keep-all;
@@ -327,6 +322,7 @@
 }
 .entry-style ol:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) > li > * {
   /* ブロックエディタ：リセット用 */
+  grid-column: 2; /* li 内に複数の要素がある場合もテキスト列に配置 */
   margin-bottom: 0;
 }
 .entry-style ol:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) > li ol {
@@ -564,9 +560,6 @@
           mask-size: contain;
 }
 @media (hover: hover) {
-  .entry-style blockquote:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) a:-moz-any-link:hover {
-    text-decoration: none;
-  }
   .entry-style blockquote:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) a:any-link:hover {
     text-decoration: none;
   }
@@ -641,10 +634,6 @@
 @media (any-hover: hover) {
   :where(.entry-style) [data-type=linkButton] a {
     transition: background-color 0.2s ease;
-  }
-  :where(.entry-style) [data-type=linkButton] a:where(:-moz-any-link):hover {
-    background: var(--color-primary-hover);
-    opacity: 1;
   }
   :where(.entry-style) [data-type=linkButton] a:where(:any-link):hover {
     background: var(--color-primary-hover);
@@ -721,10 +710,8 @@
   .entry-style .message-image img {
     width: 100%;
     height: 100%;
-    -o-object-fit: cover;
-       object-fit: cover;
-    -o-object-position: center;
-       object-position: center;
+    object-fit: cover;
+    object-position: center;
   }
   .entry-style .message-lead {
     height: auto;
@@ -775,20 +762,20 @@
 [class*=column-embed-] .acms-embed-link-title {
   margin: 0 0 0.25rem;
   overflow: hidden;
+  text-overflow: ellipsis;
   font-size: 1rem;
   font-weight: bold;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 [class*=column-embed-] .acms-embed-link-description {
   display: -webkit-box;
   margin: 0;
   overflow: hidden;
-  font-size: 0.8rem;
-  color: var(--color-text-2nd);
   text-overflow: ellipsis;
   -webkit-line-clamp: 2;
   line-clamp: 2;
+  font-size: 0.8rem;
+  color: var(--color-text-2nd);
   -webkit-box-orient: vertical;
 }
 @media (min-width: 48rem) {
@@ -804,8 +791,7 @@
   [class*=column-embed-] .acms-embed-link-image-container img {
     width: 100%;
     height: 100%;
-    -o-object-fit: cover;
-       object-fit: cover;
+    object-fit: cover;
   }
   [class*=column-embed-] .acms-embed-link-content {
     box-sizing: border-box;
@@ -819,9 +805,9 @@
   [class*=column-embed-] .acms-embed-link-title {
     margin: 0;
     overflow: hidden;
+    text-overflow: ellipsis;
     font-size: 1rem;
     font-weight: bold;
-    text-overflow: ellipsis;
     white-space: nowrap;
   }
 }
@@ -863,10 +849,6 @@
   :where(.entry-style) [class*=column-media] a[href*=storage],
   :where(.entry-style) [class*=column-file] a {
     transition: background-color 0.2s ease;
-  }
-  :where(.entry-style) [data-type=fileBlock][data-display-type=button] a:where(:-moz-any-link):hover, :where(.entry-style) [class*=column-media] a[href*=media-download]:where(:-moz-any-link):hover, :where(.entry-style) [class*=column-media] a[href*=storage]:where(:-moz-any-link):hover, :where(.entry-style) [class*=column-file] a:where(:-moz-any-link):hover {
-    background-color: var(--color-gray20);
-    border-color: var(--color-gray40); /* hover動作上書きのため */
   }
   :where(.entry-style) [data-type=fileBlock][data-display-type=button] a:where(:any-link):hover,
   :where(.entry-style) [class*=column-media] a[href*=media-download]:where(:any-link):hover,
@@ -954,8 +936,7 @@
   width: 100%;
   height: 100%;
   color: inherit;
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 :where(.entry-style) .column-pdf-image-caption-box .column-pdf-image-download-icon svg path {
   stroke: currentcolor;
@@ -1106,8 +1087,8 @@
   border-top: 0;
 }
 .entry-style table:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) th {
-  text-align: left;
   vertical-align: top;
+  text-align: left;
   background-color: var(--color-gray10);
 }
 .entry-style table:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) td {
@@ -1139,9 +1120,6 @@
           mask-size: contain;
 }
 @media (hover: hover) {
-  .entry-style table:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) a:-moz-any-link:hover {
-    text-decoration: none;
-  }
   .entry-style table:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) a:any-link:hover {
     text-decoration: none;
   }

--- a/themes/beginner/src/scss/editor/elements/_typography.scss
+++ b/themes/beginner/src/scss/editor/elements/_typography.scss
@@ -182,7 +182,6 @@
     display: grid;
     grid-template-columns: subgrid; /* アイテム番号の幅を揃えるための設定 */
     grid-column: 1 / -1; /* 列をまたいで全幅を確保 */
-    grid-auto-flow: column;
     font-size: map.get(global.$font-scales, body-m);
     line-height: var(--line-height-base);
 
@@ -192,7 +191,6 @@
 
     &::before {
       grid-column: 1;
-      padding-top: 1.4px; /* 番号位置の微調整 */
       font-weight: bold;
       color: var(--color-text-2nd);
       word-break: keep-all;
@@ -203,6 +201,7 @@
 
     & > * {
       /* ブロックエディタ：リセット用 */
+      grid-column: 2; /* li 内に複数の要素がある場合もテキスト列に配置 */
       margin-bottom: 0;
     }
 

--- a/themes/site/dest/bundle.css
+++ b/themes/site/dest/bundle.css
@@ -50,10 +50,6 @@ a {
   border: none;
 }
 
-::-moz-placeholder {
-  color: var(--color-gray70) !important;
-}
-
 ::placeholder {
   color: var(--color-gray70) !important;
 }
@@ -286,8 +282,7 @@ a {
 .main-visual-slider .splide__slide img,
 .banner-slide .splide__slide picture,
 .banner-slide .splide__slide img {
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 .main-visual-slider .splide__toggle,
 .banner-slide .splide__toggle {
@@ -483,9 +478,6 @@ a {
   text-decoration: none;
 }
 @media (hover: hover) {
-  .banner-link:-moz-any-link:hover .banner-img {
-    box-shadow: var(--box-shadow-hover);
-  }
   .banner-link:any-link:hover .banner-img {
     box-shadow: var(--box-shadow-hover);
   }
@@ -521,10 +513,6 @@ a {
   border-radius: var(--border-radius-md);
   transition: background-color 0.2s;
 }
-.button:-moz-any-link {
-  color: var(--color-white);
-  text-decoration: none;
-}
 .button:any-link {
   color: var(--color-white);
   text-decoration: none;
@@ -539,9 +527,6 @@ a {
 .button.is-bg-white {
   background: var(--color-white);
 }
-.button.is-bg-white:-moz-any-link {
-  color: var(--color-text);
-}
 .button.is-bg-white, .button.is-bg-white:any-link {
   color: var(--color-text);
 }
@@ -551,9 +536,6 @@ a {
 .button.is-bg-white-bordered {
   background: var(--color-white);
   border: var(--border-width-sm) solid var(--color-gray30);
-}
-.button.is-bg-white-bordered:-moz-any-link {
-  color: var(--color-text);
 }
 .button.is-bg-white-bordered, .button.is-bg-white-bordered:any-link {
   color: var(--color-text);
@@ -577,8 +559,7 @@ a {
   height: auto;
   aspect-ratio: 1/1;
   color: inherit;
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .button-icon svg path {
   stroke: currentcolor;
@@ -604,9 +585,6 @@ a {
   animation: fade-in 0.2s 1.2s 1 both;
 }
 @media (hover: hover) {
-  .button-view-all-articles:-moz-any-link:hover .button-view-all-articles-icon {
-    background-color: var(--color-icon-bg-hover);
-  }
   .button-view-all-articles:any-link:hover .button-view-all-articles-icon {
     background-color: var(--color-icon-bg-hover);
   }
@@ -631,8 +609,7 @@ a {
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .button-view-all-articles-icon svg path {
   stroke: currentcolor;
@@ -807,10 +784,6 @@ a {
   text-decoration: none;
 }
 @media (hover: hover) {
-  .calendar-header-title a:-moz-any-link:hover {
-    text-decoration: underline dotted 1px;
-    text-underline-offset: 3px;
-  }
   .calendar-header-title a:any-link:hover {
     -webkit-text-decoration: underline dotted 1px;
             text-decoration: underline dotted 1px;
@@ -890,9 +863,6 @@ a {
   text-decoration: none;
 }
 @media (hover: hover) {
-  .calendar-pagination-link:-moz-any-link:hover .calendar-pagination-link-icon {
-    background-color: var(--color-icon-bg-hover);
-  }
   .calendar-pagination-link:any-link:hover .calendar-pagination-link-icon {
     background-color: var(--color-icon-bg-hover);
   }
@@ -922,8 +892,7 @@ a {
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .calendar-pagination-link-icon svg path {
   stroke: currentcolor;
@@ -957,8 +926,7 @@ a {
   width: 0.657rem;
   height: 0.657rem;
   color: inherit;
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .calendar-next-prev-button svg path {
   stroke: currentcolor;
@@ -985,9 +953,6 @@ a {
   text-decoration: none;
 }
 @media (hover: hover) {
-  .section-side-link:-moz-any-link:hover .section-side-link-icon {
-    background-color: var(--color-icon-bg-hover);
-  }
   .section-side-link:any-link:hover .section-side-link-icon {
     background-color: var(--color-icon-bg-hover);
   }
@@ -1012,8 +977,7 @@ a {
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .section-side-link-icon svg path {
   stroke: currentcolor;
@@ -1128,9 +1092,6 @@ a {
   .calendar-event-item-link {
     transition: background-color 0.3s ease;
   }
-  .calendar-event-item-link:-moz-any-link:hover {
-    background-color: var(--color-hover-bg-2nd);
-  }
   .calendar-event-item-link:any-link:hover {
     background-color: var(--color-hover-bg-2nd);
   }
@@ -1193,8 +1154,7 @@ a {
   width: 11.25rem;
   height: auto;
   aspect-ratio: 16/9;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   border-radius: var(--border-radius-lg);
 }
 @media (min-width: 30rem) {
@@ -1373,9 +1333,6 @@ a {
   border-bottom: var(--border-width-sm) dotted var(--color-white);
 }
 @media (hover: hover) {
-  .cta-visual a[href^="tel:"]:-moz-any-link:hover {
-    border-color: transparent;
-  }
   .cta-visual a[href^="tel:"]:any-link:hover {
     border-color: transparent;
   }
@@ -1983,9 +1940,9 @@ a {
   padding: 0;
   margin: 0;
   overflow: hidden;
+  list-style-type: "";
   border-radius: var(--border-radius-lg);
   box-shadow: var(--box-shadow);
-  list-style-type: "";
 }
 .js .headline-list.js-animation-row {
   opacity: 0;
@@ -2007,9 +1964,6 @@ a {
 @media (hover: hover) {
   .headline-link {
     transition: background-color 0.3s ease;
-  }
-  .headline-link:-moz-any-link:hover {
-    background-color: var(--color-hover-bg-2nd);
   }
   .headline-link:any-link:hover {
     background-color: var(--color-hover-bg-2nd);
@@ -2450,7 +2404,6 @@ a {
     padding: 0.75rem;
   }
   .form-group select {
-    width: -moz-fit-content;
     width: fit-content;
   }
 }
@@ -2869,8 +2822,7 @@ a {
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .local-nav-link-icon svg path {
   stroke: currentcolor;
@@ -2926,8 +2878,7 @@ a {
 .main-visual .main-visual-bg img {
   width: 100%;
   height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 .main-visual .main-visual-box {
   position: absolute;
@@ -3086,8 +3037,7 @@ a {
 .main-visual-extend01 .main-visual-bg img {
   width: 100%;
   height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 .main-visual-extend01 .main-visual-box {
   position: absolute;
@@ -3292,8 +3242,7 @@ a {
 .main-visual-extend02 .main-visual-bg img {
   width: 100%;
   height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 @media (min-width: 48rem) {
   .main-visual-extend02 .main-visual-bg img {
@@ -3463,13 +3412,6 @@ a {
   }
 }
 @media (hover: hover) and (min-width: 30rem) {
-  .media-item-link:-moz-any-link:hover {
-    /*
-    * sm幅以上でのみ、リンクホバー時に背景色が表示されるように設定しています。
-    * この背景色は、シャドウのようにコンテンツからはみ出して表示されます。
-    * sm幅未満では画面端に角丸背景色が接することで、視覚的バランスを損なうため適用していません。
-    */
-  }
   .media-item-link:any-link:hover {
     /*
     * sm幅以上でのみ、リンクホバー時に背景色が表示されるように設定しています。
@@ -3477,22 +3419,13 @@ a {
     * sm幅未満では画面端に角丸背景色が接することで、視覚的バランスを損なうため適用していません。
     */
   }
-  .media-item-link:-moz-any-link:hover::after {
-    background-color: var(--color-hover-bg-2nd);
-  }
   .media-item-link:any-link:hover::after {
     background-color: var(--color-hover-bg-2nd);
   }
 }
 @media (hover: hover) {
-  .media-item-link:-moz-any-link:hover .media-item-img {
-    transform: scale(1.2);
-  }
   .media-item-link:any-link:hover .media-item-img {
     transform: scale(1.2);
-  }
-  .media-item-link:-moz-any-link:hover .media-item-read-more-icon {
-    background-color: var(--color-icon-bg-hover);
   }
   .media-item-link:any-link:hover .media-item-read-more-icon {
     background-color: var(--color-icon-bg-hover);
@@ -3546,8 +3479,7 @@ a {
   display: block;
   width: 100%;
   height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 /* テキスト類全体の縦積みレイアウト */
@@ -3615,9 +3547,9 @@ a {
   flex-wrap: wrap;
   gap: 0.25rem 1rem;
   align-items: flex-start;
+  padding-inline-start: 0;
   margin-top: 0;
   margin-bottom: 0;
-  padding-inline-start: 0;
   line-height: var(--line-height-none);
   list-style-type: "";
 }
@@ -3662,8 +3594,7 @@ a {
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .media-item-read-more-icon svg path {
   stroke: currentcolor;
@@ -3730,7 +3661,6 @@ a {
 }
 
 .page-title-text-wrap {
-  width: -moz-fit-content;
   width: fit-content;
 }
 .page-title-text-wrap.left {
@@ -3864,15 +3794,8 @@ a {
   color: inherit;
 }
 @media (hover: hover) {
-  .pager-link:-moz-any-link {
-    -moz-transition: background-color 0.3s ease;
-    transition: background-color 0.3s ease;
-  }
   .pager-link:any-link {
     transition: background-color 0.3s ease;
-  }
-  .pager-link:-moz-any-link:hover {
-    background-color: var(--color-hover-bg);
   }
   .pager-link:any-link:hover {
     background-color: var(--color-hover-bg);
@@ -3914,24 +3837,16 @@ a {
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .pager-simple-arrow-icon svg path,
 .serial-nav-arrow-icon svg path {
   stroke: currentcolor;
 }
 @media (hover: hover) {
-  a:-moz-any-link .pager-simple-arrow-icon, a:-moz-any-link .serial-nav-arrow-icon {
-    -moz-transition: background-color 0.3s ease;
-    transition: background-color 0.3s ease;
-  }
   a:any-link .pager-simple-arrow-icon,
   a:any-link .serial-nav-arrow-icon {
     transition: background-color 0.3s ease;
-  }
-  a:-moz-any-link:hover .pager-simple-arrow-icon, a:-moz-any-link:hover .serial-nav-arrow-icon {
-    background-color: var(--color-icon-bg-hover);
   }
   a:any-link:hover .pager-simple-arrow-icon,
   a:any-link:hover .serial-nav-arrow-icon {
@@ -3976,9 +3891,6 @@ a {
 @media (hover: hover) {
   .pager-simple-link {
     transition: background-color 0.3s ease;
-  }
-  .pager-simple-link:-moz-any-link:hover {
-    background-color: var(--color-hover-bg-2nd);
   }
   .pager-simple-link:any-link:hover {
     background-color: var(--color-hover-bg-2nd);
@@ -4068,9 +3980,6 @@ a {
   .serial-nav-item-prev a,
   .serial-nav-item-next a {
     transition: background-color 0.3s ease;
-  }
-  .serial-nav-item-prev a:-moz-any-link:hover, .serial-nav-item-next a:-moz-any-link:hover {
-    background-color: var(--color-hover-bg-2nd);
   }
   .serial-nav-item-prev a:any-link:hover,
   .serial-nav-item-next a:any-link:hover {
@@ -4201,9 +4110,7 @@ a {
   height: 32px;
   padding: 0;
   margin-bottom: 12px;
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
+  appearance: none;
   background-color: var(--color-icon-bg);
   border-width: 0;
   border-radius: 32px;
@@ -4330,9 +4237,6 @@ a {
   text-decoration: none;
 }
 @media (hover: hover) {
-  .profile-author-link:-moz-any-link:hover .profile-author-link-icon {
-    background-color: var(--color-icon-bg-hover);
-  }
   .profile-author-link:any-link:hover .profile-author-link-icon {
     background-color: var(--color-icon-bg-hover);
   }
@@ -4357,8 +4261,7 @@ a {
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .profile-author-link-icon svg path {
   stroke: currentcolor;
@@ -4409,9 +4312,7 @@ a {
   height: 3rem;
   padding: 0.75rem 1rem;
   font-size: 1rem;
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
+  appearance: none;
   background: var(--color-white);
   border: var(--border-width-sm) solid var(--color-gray30);
   border-radius: var(--border-radius-md);
@@ -4709,9 +4610,6 @@ a {
   .tag-filter-selected-item a {
     transition: opacity 0.3s ease;
   }
-  .tag-filter-selected-item a:-moz-any-link:hover {
-    opacity: 0.6;
-  }
   .tag-filter-selected-item a:any-link:hover {
     opacity: 0.6;
   }
@@ -4737,10 +4635,6 @@ a {
   font-size: 1rem;
   color: var(--color-text);
 }
-.tag-filter-choice-item a:-moz-any-link {
-  text-decoration: underline dotted 1px;
-  text-underline-offset: 3px;
-}
 .tag-filter-choice-item a:any-link {
   -webkit-text-decoration: underline dotted 1px;
           text-decoration: underline dotted 1px;
@@ -4750,9 +4644,6 @@ a {
   color: inherit;
 }
 @media (hover: hover) {
-  .tag-filter-choice-item a:-moz-any-link:hover {
-    text-decoration: none;
-  }
   .tag-filter-choice-item a:any-link:hover {
     text-decoration: none;
   }
@@ -4821,10 +4712,6 @@ a {
   text-decoration: none;
 }
 @media (hover: hover) {
-  .topicpath-link:-moz-any-link:hover {
-    text-decoration: underline dotted 1px;
-    text-underline-offset: 3px;
-  }
   .topicpath-link:any-link:hover {
     -webkit-text-decoration: underline dotted 1px;
             text-decoration: underline dotted 1px;
@@ -4922,9 +4809,6 @@ a {
   color: inherit;
 }
 @media (hover: hover) {
-  .paragraph a:-moz-any-link:hover {
-    border-bottom-color: transparent;
-  }
   .paragraph a:any-link:hover {
     border-bottom-color: transparent;
   }
@@ -5134,9 +5018,6 @@ a {
   color: var(--color-text);
 }
 @media (hover: hover) {
-  .entry-header-category-label:-moz-any-link:hover {
-    background-color: var(--color-hover-bg-2nd);
-  }
   .entry-header-category-label:any-link:hover {
     background-color: var(--color-hover-bg-2nd);
   }
@@ -5197,10 +5078,6 @@ a {
   font-size: 0.8rem;
   color: var(--color-text);
 }
-.entry-tag-item a:-moz-any-link {
-  text-decoration: underline dotted 1px;
-  text-underline-offset: 3px;
-}
 .entry-tag-item a:any-link {
   -webkit-text-decoration: underline dotted 1px;
           text-decoration: underline dotted 1px;
@@ -5210,9 +5087,6 @@ a {
   color: inherit;
 }
 @media (hover: hover) {
-  .entry-tag-item a:-moz-any-link:hover {
-    text-decoration: none;
-  }
   .entry-tag-item a:any-link:hover {
     text-decoration: none;
   }
@@ -5296,8 +5170,7 @@ a {
     width: 100%;
     height: 100%;
     vertical-align: bottom;
-    -o-object-fit: cover;
-       object-fit: cover;
+    object-fit: cover;
   }
   .entry-header-visual-title {
     font-size: 1.5625rem;
@@ -5531,8 +5404,7 @@ a {
 .bubble-image-wrap img {
   width: 6rem;
   height: 6rem;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   border-radius: var(--border-radius-round);
 }
 
@@ -5654,9 +5526,6 @@ a {
           mask-size: contain;
 }
 @media (hover: hover) {
-  .detail-panel a:-moz-any-link:hover {
-    text-decoration: none;
-  }
   .detail-panel a:any-link:hover {
     text-decoration: none;
   }
@@ -5800,9 +5669,6 @@ a {
   color: inherit;
 }
 @media (hover: hover) {
-  .section-horizontal-text a:-moz-any-link:hover {
-    border-bottom-color: transparent;
-  }
   .section-horizontal-text a:any-link:hover {
     border-bottom-color: transparent;
   }
@@ -6000,14 +5866,8 @@ a {
 }
 
 @media (hover: hover) {
-  .summary-side-link:-moz-any-link:hover::after {
-    background-color: var(--color-hover-bg-2nd);
-  }
   .summary-side-link:any-link:hover::after {
     background-color: var(--color-hover-bg-2nd);
-  }
-  .summary-side-link:-moz-any-link:hover .summary-side-img {
-    transform: scale(1.2);
   }
   .summary-side-link:any-link:hover .summary-side-img {
     transform: scale(1.2);
@@ -6032,8 +5892,7 @@ a {
   display: block;
   width: 100%;
   height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   transition: transform 0.4s 0.2s ease-out;
   will-change: transform;
 }
@@ -6169,10 +6028,6 @@ a {
 .footer-address-item a {
   color: inherit;
 }
-.footer-address-item a:-moz-any-link {
-  text-decoration: underline dotted 1px;
-  text-underline-offset: 3px;
-}
 .footer-address-item a:any-link {
   -webkit-text-decoration: underline dotted 1px;
           text-decoration: underline dotted 1px;
@@ -6237,10 +6092,6 @@ a {
   text-decoration: none;
 }
 @media (hover: hover) {
-  .footer-nav-link:-moz-any-link:hover {
-    text-decoration: underline dotted 1px;
-    text-underline-offset: 3px;
-  }
   .footer-nav-link:any-link:hover {
     -webkit-text-decoration: underline dotted 1px;
             text-decoration: underline dotted 1px;
@@ -6479,8 +6330,7 @@ a {
   height: auto;
   aspect-ratio: 1/1;
   color: inherit;
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .header-search-open-button-icon svg path {
   stroke: currentcolor;
@@ -6893,8 +6743,7 @@ a {
   width: 100%;
   height: 100%;
   color: inherit;
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .event-googlemap-link-icon svg path {
   fill: currentcolor;

--- a/themes/site/dest/editor.css
+++ b/themes/site/dest/editor.css
@@ -93,9 +93,6 @@
           mask-size: contain;
 }
 @media (hover: hover) {
-  .entry-style a:not(:where([class~=not-editor-style], [class~=not-editor-style] *, [class~=media-image-block], [class~=media-image-block] *, [class~=column-image], [class~=column-image] *, [class~=column-media], [class~=column-media] *, [class~=column-eximage], [class~=column-eximage] *)):-moz-any-link:hover {
-    text-decoration: none;
-  }
   .entry-style a:not(:where([class~=not-editor-style], [class~=not-editor-style] *, [class~=media-image-block], [class~=media-image-block] *, [class~=column-image], [class~=column-image] *, [class~=column-media], [class~=column-media] *, [class~=column-eximage], [class~=column-eximage] *)):any-link:hover {
     text-decoration: none;
   }
@@ -127,9 +124,6 @@
           mask-size: contain;
 }
 @media (hover: hover) {
-  .entryFormLiteEditor a:-moz-any-link:hover {
-    text-decoration: none;
-  }
   .entryFormLiteEditor a:any-link:hover {
     text-decoration: none;
   }
@@ -342,7 +336,6 @@
   display: grid;
   grid-template-columns: subgrid; /* アイテム番号の幅を揃えるための設定 */
   grid-column: 1/-1; /* 列をまたいで全幅を確保 */
-  grid-auto-flow: column;
   font-size: 1rem;
   line-height: var(--line-height-base);
 }
@@ -351,7 +344,6 @@
 }
 .entry-style ol:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) > li::before {
   grid-column: 1;
-  padding-top: 1.4px; /* 番号位置の微調整 */
   font-weight: bold;
   color: var(--color-text-2nd);
   word-break: keep-all;
@@ -361,6 +353,7 @@
 }
 .entry-style ol:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) > li > * {
   /* ブロックエディタ：リセット用 */
+  grid-column: 2; /* li 内に複数の要素がある場合もテキスト列に配置 */
   margin-block: 0;
 }
 .entry-style ol:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) > li ol {
@@ -633,9 +626,6 @@
           mask-size: contain;
 }
 @media (hover: hover) {
-  .entry-style blockquote:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) a:-moz-any-link:hover {
-    text-decoration: none;
-  }
   .entry-style blockquote:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) a:any-link:hover {
     text-decoration: none;
   }
@@ -710,10 +700,6 @@
 @media (any-hover: hover) {
   :where(.entry-style) [data-type=linkButton] a {
     transition: background-color 0.2s ease;
-  }
-  :where(.entry-style) [data-type=linkButton] a:where(:-moz-any-link):hover {
-    background: var(--color-primary-hover);
-    opacity: 1;
   }
   :where(.entry-style) [data-type=linkButton] a:where(:any-link):hover {
     background: var(--color-primary-hover);
@@ -806,10 +792,6 @@
   .entry-style .entry-outline-list-wrap .outline-item a {
     transition: color 0.25s ease;
   }
-  .entry-style .entry-outline-list-wrap .outline-item a:-moz-any-link:hover {
-    color: var(--color-primary);
-    cursor: pointer;
-  }
   .entry-style .entry-outline-list-wrap .outline-item a:any-link:hover {
     color: var(--color-primary);
     cursor: pointer;
@@ -882,10 +864,8 @@
   .entry-style .message-image img {
     width: 100%;
     height: 100%;
-    -o-object-fit: cover;
-       object-fit: cover;
-    -o-object-position: center;
-       object-position: center;
+    object-fit: cover;
+    object-position: center;
   }
   .entry-style .message-lead {
     font-size: 1.5625rem;
@@ -1104,8 +1084,7 @@
   [class*=column-embed-] .acms-embed-link-image-container img {
     width: 100%;
     height: 100%;
-    -o-object-fit: cover;
-       object-fit: cover;
+    object-fit: cover;
   }
   [class*=column-embed-] .acms-embed-link-content {
     box-sizing: border-box;
@@ -1163,10 +1142,6 @@
   :where(.entry-style) [class*=column-media] a[href*=storage],
   :where(.entry-style) [class*=column-file] a {
     transition: background-color 0.2s ease;
-  }
-  :where(.entry-style) [data-type=fileBlock][data-display-type=button] a:where(:-moz-any-link):hover, :where(.entry-style) [class*=column-media] a[href*=media-download]:where(:-moz-any-link):hover, :where(.entry-style) [class*=column-media] a[href*=storage]:where(:-moz-any-link):hover, :where(.entry-style) [class*=column-file] a:where(:-moz-any-link):hover {
-    background-color: var(--color-gray20);
-    border-color: var(--color-gray40); /* hover動作上書きのため */
   }
   :where(.entry-style) [data-type=fileBlock][data-display-type=button] a:where(:any-link):hover,
   :where(.entry-style) [class*=column-media] a[href*=media-download]:where(:any-link):hover,
@@ -1254,8 +1229,7 @@
   width: 100%;
   height: 100%;
   color: inherit;
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 :where(.entry-style) .column-pdf-image-caption-box .column-pdf-image-download-icon svg path {
   stroke: currentcolor;
@@ -1439,9 +1413,6 @@
           mask-size: contain;
 }
 @media (hover: hover) {
-  .entry-style table:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) a:-moz-any-link:hover {
-    text-decoration: none;
-  }
   .entry-style table:not(:where([class~=not-editor-style], [class~=not-editor-style] *)) a:any-link:hover {
     text-decoration: none;
   }
@@ -1510,16 +1481,9 @@
     transition: 0.4s 0.2s ease-out;
     will-change: transform;
   }
-  .card-bordered-link:-moz-any-link:hover .card-bordered {
-    background-color: var(--color-hover-bg-2nd);
-    box-shadow: var(--box-shadow-hover);
-  }
   .card-bordered-link:any-link:hover .card-bordered {
     background-color: var(--color-hover-bg-2nd);
     box-shadow: var(--box-shadow-hover);
-  }
-  .card-bordered-link:-moz-any-link:hover .card-bordered-img {
-    transform: scale(1.2);
   }
   .card-bordered-link:any-link:hover .card-bordered-img {
     transform: scale(1.2);
@@ -1555,8 +1519,7 @@
 .card-bordered-img {
   width: 100%;
   height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 .card-bordered-text-layout {
@@ -1618,13 +1581,6 @@
   }
 }
 @media (hover: hover) and (min-width: 30rem) {
-  .card-link:-moz-any-link:hover {
-    /*
-      * sm幅以上でのみ、リンクホバー時に背景色が表示されるように設定しています。
-      * この背景色は、シャドウのようにコンテンツからはみ出して表示されます。
-      * sm幅未満では画面端に角丸背景色が接することで、視覚的バランスを損なうため適用していません。
-      */
-  }
   .card-link:any-link:hover {
     /*
       * sm幅以上でのみ、リンクホバー時に背景色が表示されるように設定しています。
@@ -1632,22 +1588,13 @@
       * sm幅未満では画面端に角丸背景色が接することで、視覚的バランスを損なうため適用していません。
       */
   }
-  .card-link:-moz-any-link:hover::after {
-    background-color: var(--color-hover-bg-2nd);
-  }
   .card-link:any-link:hover::after {
     background-color: var(--color-hover-bg-2nd);
   }
 }
 @media (hover: hover) {
-  .card-link:-moz-any-link:hover .card-img {
-    transform: scale(1.2);
-  }
   .card-link:any-link:hover .card-img {
     transform: scale(1.2);
-  }
-  .card-link:-moz-any-link:hover .card-read-more-icon {
-    background-color: var(--color-icon-bg-hover);
   }
   .card-link:any-link:hover .card-read-more-icon {
     background-color: var(--color-icon-bg-hover);
@@ -1689,8 +1636,7 @@
   width: 100%;
   height: auto;
   aspect-ratio: var(--card-img-aspect-ratio, 16/9);
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 /* 画像上に重ねて表示するラベル */
@@ -1810,9 +1756,9 @@
   flex-wrap: wrap;
   gap: 0.25rem 1rem;
   align-items: flex-start;
+  padding-inline-start: 0;
   margin-top: 0;
   margin-bottom: 0;
-  padding-inline-start: 0;
   line-height: var(--line-height-none);
   list-style-type: none;
 }
@@ -1895,8 +1841,7 @@
   width: 0.625rem;
   height: 0.625rem;
   color: var(--color-white);
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .card-read-more-icon svg path {
   stroke: currentcolor;
@@ -2165,8 +2110,7 @@
   width: 100%;
   height: 100%;
   color: inherit;
-  -o-object-fit: contain;
-     object-fit: contain;
+  object-fit: contain;
 }
 .toggle-icon svg path {
   stroke: currentcolor;

--- a/themes/site/src/scss/editor/elements/_typography.scss
+++ b/themes/site/src/scss/editor/elements/_typography.scss
@@ -188,7 +188,6 @@
     display: grid;
     grid-template-columns: subgrid; /* アイテム番号の幅を揃えるための設定 */
     grid-column: 1 / -1; /* 列をまたいで全幅を確保 */
-    grid-auto-flow: column;
     font-size: map.get(global.$font-scales, body-m);
     line-height: var(--line-height-base);
 
@@ -198,7 +197,6 @@
 
     &::before {
       grid-column: 1;
-      padding-top: 1.4px; /* 番号位置の微調整 */
       font-weight: bold;
       color: var(--color-text-2nd);
       word-break: keep-all;
@@ -209,6 +207,7 @@
 
     & > * {
       /* ブロックエディタ：リセット用 */
+      grid-column: 2; /* li 内に複数の要素がある場合もテキスト列に配置 */
       margin-block: 0;
     }
 


### PR DESCRIPTION
Discord にて以下報告を頂き、li タグ直下に複数の p タグが存在する場合に テーマの CSS が対応できていないことが発覚しました。
https://discord.com/channels/380683533880131586/1146777710048313354/1481909224924774501

修正前
<img width="863" height="101" alt="スクリーンショット 2026-03-18 14 40 32" src="https://github.com/user-attachments/assets/496a8815-210c-44ed-992b-6bc4811ed5f5" />

修正後
<img width="1149" height="129" alt="スクリーンショット 2026-03-18 14 41 07" src="https://github.com/user-attachments/assets/4de63595-8206-4f20-943a-783c91ebaca6" />
