### PR TITLE
site/beginnerの共通SCSSをsystemテーマ相対参照からnpm(@ablogcms/acms.css)に変更

### DIFF
--- a/themes/beginner/package-lock.json
+++ b/themes/beginner/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.9",
       "license": "MIT",
       "devDependencies": {
+        "@ablogcms/acms.css": "^3.2.29",
         "autoprefixer": "^10.4.21",
         "browserslist": "^4.28.1",
         "css-loader": "^7.1.2",
@@ -28,6 +29,17 @@
         "webpack-fix-style-only-entries": "^0.6.1",
         "webpack-merge": "^6.0.1",
         "webpack-remove-empty-scripts": "^1.1.1"
+      }
+    },
+    "node_modules/@ablogcms/acms.css": {
+      "version": "3.2.29",
+      "resolved": "https://registry.npmjs.org/@ablogcms/acms.css/-/acms.css-3.2.29.tgz",
+      "integrity": "sha512-gpExOmvIucX9OqXzs5ZoP5pDG/PwqRzhY1eXI8NPVNjwfUPOlEf8xF7k2yCb6isGQUjU3cS9Cmd50xa3blfl1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "normalize.css": "^8.0.1",
+        "reset-css": "^5.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3638,6 +3650,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -4292,6 +4311,13 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
+    },
+    "node_modules/reset-css": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/reset-css/-/reset-css-5.0.2.tgz",
+      "integrity": "sha512-YtgUGSq5z5W0NPSjsBW7ys7rtWa8P8AiE7S6Fg3d1TQCPpAodgYyLuZYlU0AOsLtprk/fC9ormHN/0pAavVIDw==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -6087,6 +6113,16 @@
     }
   },
   "dependencies": {
+    "@ablogcms/acms.css": {
+      "version": "3.2.29",
+      "resolved": "https://registry.npmjs.org/@ablogcms/acms.css/-/acms.css-3.2.29.tgz",
+      "integrity": "sha512-gpExOmvIucX9OqXzs5ZoP5pDG/PwqRzhY1eXI8NPVNjwfUPOlEf8xF7k2yCb6isGQUjU3cS9Cmd50xa3blfl1g==",
+      "dev": true,
+      "requires": {
+        "normalize.css": "^8.0.1",
+        "reset-css": "^5.0.2"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -8611,6 +8647,12 @@
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true
     },
+    "normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
+      "dev": true
+    },
     "object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -9020,6 +9062,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
+    "reset-css": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/reset-css/-/reset-css-5.0.2.tgz",
+      "integrity": "sha512-YtgUGSq5z5W0NPSjsBW7ys7rtWa8P8AiE7S6Fg3d1TQCPpAodgYyLuZYlU0AOsLtprk/fC9ormHN/0pAavVIDw==",
       "dev": true
     },
     "resolve": {

--- a/themes/beginner/package.json
+++ b/themes/beginner/package.json
@@ -25,6 +25,7 @@
   "author": "appleple",
   "license": "MIT",
   "devDependencies": {
+    "@ablogcms/acms.css": "^3.2.29",
     "autoprefixer": "^10.4.21",
     "browserslist": "^4.28.1",
     "css-loader": "^7.1.2",

--- a/themes/beginner/src/scss/global/_acms-common.scss
+++ b/themes/beginner/src/scss/global/_acms-common.scss
@@ -1,8 +1,8 @@
-@forward "../../../../system/src/scss/global/variables" with (
+@forward "@ablogcms/acms.css/src/scss/global/variables" with (
   $entry-class : entry-style, // クラス名を変更する時は /include/edit/custom.js も変更すること
   $breakpoint-sm-min    : 30rem,
   $breakpoint-md-min    : 48rem,
   $breakpoint-lg-min    : 64rem,
   $breakpoint-xl-min    : 90rem,
 );
-@forward "../../../../system/src/scss/global/mixins";
+@forward "@ablogcms/acms.css/src/scss/global/mixins";

--- a/themes/beginner/src/scss/global/_acms-common.scss
+++ b/themes/beginner/src/scss/global/_acms-common.scss
@@ -1,8 +1,8 @@
-@forward "@ablogcms/acms.css/src/scss/global/variables" with (
+@forward "pkg:@ablogcms/acms.css/scss/global/variables" with (
   $entry-class : entry-style, // クラス名を変更する時は /include/edit/custom.js も変更すること
   $breakpoint-sm-min    : 30rem,
   $breakpoint-md-min    : 48rem,
   $breakpoint-lg-min    : 64rem,
   $breakpoint-xl-min    : 90rem,
 );
-@forward "@ablogcms/acms.css/src/scss/global/mixins";
+@forward "pkg:@ablogcms/acms.css/scss/global/mixins";

--- a/themes/beginner/webpack.common.js
+++ b/themes/beginner/webpack.common.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const StylelintPlugin = require('stylelint-webpack-plugin');
 const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
@@ -61,9 +60,10 @@ module.exports = {
               sourceMap: true,
               sassOptions: {
                 style: 'expanded',
-                // @ablogcms/acms.css からの共通変数・mixin読み込み（_acms-common.scss）を
-                // node_modules 経由で解決する。
-                loadPaths: [path.resolve(__dirname, 'node_modules')],
+                // @ablogcms/acms.css からの共通変数・mixin読み込み（_acms-common.scss の
+                // pkg:@ablogcms/acms.css/scss/... インポート）を package.json#exports 経由で
+                // 解決する。
+                importers: [new sass.NodePackageImporter()],
               },
             },
           },

--- a/themes/beginner/webpack.common.js
+++ b/themes/beginner/webpack.common.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const StylelintPlugin = require('stylelint-webpack-plugin');
 const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
@@ -60,6 +61,9 @@ module.exports = {
               sourceMap: true,
               sassOptions: {
                 style: 'expanded',
+                // @ablogcms/acms.css からの共通変数・mixin読み込み（_acms-common.scss）を
+                // node_modules 経由で解決する。
+                loadPaths: [path.resolve(__dirname, 'node_modules')],
               },
             },
           },

--- a/themes/site/package-lock.json
+++ b/themes/site/package-lock.json
@@ -12,6 +12,7 @@
         "dom-content-loaded": "^1.0.2"
       },
       "devDependencies": {
+        "@ablogcms/acms.css": "^3.2.29",
         "@babel/cli": "^7.28.0",
         "@babel/core": "^7.28.0",
         "@babel/eslint-parser": "^7.28.0",
@@ -42,6 +43,17 @@
         "webpack-fix-style-only-entries": "^0.6.1",
         "webpack-merge": "^6.0.1",
         "webpack-remove-empty-scripts": "^1.1.1"
+      }
+    },
+    "node_modules/@ablogcms/acms.css": {
+      "version": "3.2.29",
+      "resolved": "https://registry.npmjs.org/@ablogcms/acms.css/-/acms.css-3.2.29.tgz",
+      "integrity": "sha512-gpExOmvIucX9OqXzs5ZoP5pDG/PwqRzhY1eXI8NPVNjwfUPOlEf8xF7k2yCb6isGQUjU3cS9Cmd50xa3blfl1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "normalize.css": "^8.0.1",
+        "reset-css": "^5.0.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6945,6 +6957,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7882,6 +7901,13 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
+    },
+    "node_modules/reset-css": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/reset-css/-/reset-css-5.0.2.tgz",
+      "integrity": "sha512-YtgUGSq5z5W0NPSjsBW7ys7rtWa8P8AiE7S6Fg3d1TQCPpAodgYyLuZYlU0AOsLtprk/fC9ormHN/0pAavVIDw==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -10096,6 +10122,16 @@
     }
   },
   "dependencies": {
+    "@ablogcms/acms.css": {
+      "version": "3.2.29",
+      "resolved": "https://registry.npmjs.org/@ablogcms/acms.css/-/acms.css-3.2.29.tgz",
+      "integrity": "sha512-gpExOmvIucX9OqXzs5ZoP5pDG/PwqRzhY1eXI8NPVNjwfUPOlEf8xF7k2yCb6isGQUjU3cS9Cmd50xa3blfl1g==",
+      "dev": true,
+      "requires": {
+        "normalize.css": "^8.0.1",
+        "reset-css": "^5.0.2"
+      }
+    },
     "@ampproject/remapping": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -14968,6 +15004,12 @@
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true
     },
+    "normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
+      "dev": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -15592,6 +15634,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
+    "reset-css": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/reset-css/-/reset-css-5.0.2.tgz",
+      "integrity": "sha512-YtgUGSq5z5W0NPSjsBW7ys7rtWa8P8AiE7S6Fg3d1TQCPpAodgYyLuZYlU0AOsLtprk/fC9ormHN/0pAavVIDw==",
       "dev": true
     },
     "resolve": {

--- a/themes/site/package.json
+++ b/themes/site/package.json
@@ -33,6 +33,7 @@
     "@babel/eslint-parser": "^7.28.0",
     "@babel/eslint-plugin": "^7.27.1",
     "@babel/preset-env": "^7.28.0",
+    "@ablogcms/acms.css": "^3.2.29",
     "autoprefixer": "^10.4.21",
     "babel-loader": "^10.0.0",
     "browserslist": "^4.28.1",

--- a/themes/site/src/scss/global/_acms-common.scss
+++ b/themes/site/src/scss/global/_acms-common.scss
@@ -1,8 +1,8 @@
-@forward "../../../../system/src/scss/global/variables" with (
+@forward "@ablogcms/acms.css/src/scss/global/variables" with (
   $entry-class : entry-style, // クラス名を変更する時は /include/edit/custom.js も変更すること
   $breakpoint-sm-min    : 30rem,
   $breakpoint-md-min    : 48rem,
   $breakpoint-lg-min    : 64rem,
   $breakpoint-xl-min    : 90rem,
 );
-@forward "../../../../system/src/scss/global/mixins";
+@forward "@ablogcms/acms.css/src/scss/global/mixins";

--- a/themes/site/src/scss/global/_acms-common.scss
+++ b/themes/site/src/scss/global/_acms-common.scss
@@ -1,8 +1,8 @@
-@forward "@ablogcms/acms.css/src/scss/global/variables" with (
+@forward "pkg:@ablogcms/acms.css/scss/global/variables" with (
   $entry-class : entry-style, // クラス名を変更する時は /include/edit/custom.js も変更すること
   $breakpoint-sm-min    : 30rem,
   $breakpoint-md-min    : 48rem,
   $breakpoint-lg-min    : 64rem,
   $breakpoint-xl-min    : 90rem,
 );
-@forward "@ablogcms/acms.css/src/scss/global/mixins";
+@forward "pkg:@ablogcms/acms.css/scss/global/mixins";

--- a/themes/site/webpack.common.js
+++ b/themes/site/webpack.common.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const ESLintPlugin = require('eslint-webpack-plugin');
 const StylelintPlugin = require('stylelint-webpack-plugin');
@@ -69,6 +70,9 @@ module.exports = {
               sourceMap: true,
               sassOptions: {
                 style: 'expanded',
+                // @ablogcms/acms.css からの共通変数・mixin読み込み（_acms-common.scss）を
+                // node_modules 経由で解決する。
+                loadPaths: [path.resolve(__dirname, 'node_modules')],
               },
             },
           },

--- a/themes/site/webpack.common.js
+++ b/themes/site/webpack.common.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const ESLintPlugin = require('eslint-webpack-plugin');
 const StylelintPlugin = require('stylelint-webpack-plugin');
@@ -70,9 +69,10 @@ module.exports = {
               sourceMap: true,
               sassOptions: {
                 style: 'expanded',
-                // @ablogcms/acms.css からの共通変数・mixin読み込み（_acms-common.scss）を
-                // node_modules 経由で解決する。
-                loadPaths: [path.resolve(__dirname, 'node_modules')],
+                // @ablogcms/acms.css からの共通変数・mixin読み込み（_acms-common.scss の
+                // pkg:@ablogcms/acms.css/scss/... インポート）を package.json#exports 経由で
+                // 解決する。
+                importers: [new sass.NodePackageImporter()],
               },
             },
           },


### PR DESCRIPTION
## 背景

先行PR #60（Dependabot導入）のCI検証で発覚した問題。`themes/site`・`themes/beginner` の `_acms-common.scss` は

```scss
@forward "../../../../system/src/scss/global/variables" with (...);
@forward "../../../../system/src/scss/global/mixins";
```

という相対パスで a-blog cms 本体側の `ablogcms/themes/system` を参照していた。この相対パスは302xリポジトリ内でのみ存在するローカル symlink（`themes/system`。`.gitignore` 対象で `acms-utsuwa` リポジトリには含まれない）を前提にしており、`acms-utsuwa` 単独のチェックアウト（GitHub Actions のCI等）では解決できず webpack build が失敗する。

## 対応

https://www.npmjs.com/package/@ablogcms/acms.css （a-blog cms 本体が公開しているCSSフレームワークパッケージ。`./scss/*` で `src/scss/*` をexport済み）を各テーマの `devDependencies` に追加し、`sass-loader` の `sassOptions.loadPaths` に `node_modules` を追加することで、`@ablogcms/acms.css/src/scss/global/variables` のようにパッケージ名ベースで解決するように変更した。

## 変更内容

- `themes/site/package.json`, `themes/beginner/package.json`: `@ablogcms/acms.css` を devDependencies に追加
- `themes/site/webpack.common.js`, `themes/beginner/webpack.common.js`: `sassOptions.loadPaths` に `node_modules` を追加
- `themes/site/src/scss/global/_acms-common.scss`, `themes/beginner/src/scss/global/_acms-common.scss`: `@forward` の参照先を相対パスから `@ablogcms/acms.css/src/scss/global/...` に変更

## 動作確認

- ローカルで `themes/system` symlink を一時的に外した状態（`acms-utsuwa` 単独チェックアウト相当）で `npm run build:site` / `npm run build:beginner` が成功することを確認
- 修正前後でコンパイル後のCSS出力（`dest/bundle.css`）が byte-for-byte で完全一致することを確認（変数・mixinの値は変更していないため見た目・挙動への影響なし）

## Follow-up

PR #60（Dependabot / test.yml）とは別PRとして分離した。#60 マージ後、`test.yml` に `npm run build:themes` ステップを追加してCIで webpack build 自体も検証できるようにする（このPRのマージ前は構造的に失敗するため保留していた）。