### PR TITLE
test.ymlのbuild:themes復活とpushトリガーのv4以降への汎用化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@
 # target-branch は develop/v3 を明示する。このリポジトリのデフォルトブランチは release/v3
 # （push すると release.yml が発火してリリースを作成する）で、指定しないと Dependabot は
 # release/v3 に向けてPRを作ってしまう。
+#
+# 注意: target-branch はワイルドカード非対応（Dependabotの仕様上、実ブランチ名を1つ明示する必要
+# がある）。v4 系列を始める際は、この4箇所の target-branch を develop/v4 に書き換えること
+# （test.yml の push トリガー・Rulesetの対象ブランチ条件は develop/** / release/** で汎用化済み
+# のため、そちらは変更不要）。
 version: 2
 updates:
   - package-ecosystem: "npm"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,9 +3,9 @@ name: Dependabot auto-merge
 # Auto-merge Dependabot PRs for patch and minor updates once the required checks pass.
 # Major updates are left for manual review.
 #
-# Requires (in repo Settings): "Allow auto-merge" enabled, and a branch protection rule on the
-# develop/v3 branch with the Test workflow as a required status check — otherwise --auto has no
-# check to wait for and would merge without CI.
+# Requires (in repo Settings): "Allow auto-merge" enabled, and a ruleset covering the Dependabot
+# target branch (develop/v3, see .github/dependabot.yml) with the Test workflow as a required
+# status check — otherwise --auto has no check to wait for and would merge without CI.
 on: pull_request
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,19 +1,19 @@
 name: Test
 
-# ルート（release パッケージング。themes/site・themes/beginner の npm ci を含む）を検証する。
+# ルート（release パッケージング）と themes/site・themes/beginner（webpack build）を検証する。
 # Dependabot の patch/minor 自動マージ（dependabot-auto-merge.yml）が待つ必須チェック。
 #
-# themes/site・themes/beginner の SCSS は ../../../../system/... で ablogcms/themes/system
-# （a-blog cms 本体側。302xリポジトリ内のローカル symlink 経由でのみ解決される）を相対参照して
-# いるため、このリポジトリ単独のチェックアウトでは `npm run build:themes`（webpack build）が
-# 構造的に成功しない。そのため各テーマの npm ci（依存解決）までを検証範囲とする。
+# site・beginner の SCSS は共通変数・mixin（_acms-common.scss）を @ablogcms/acms.css
+# （node_modules 経由。pkg: スキーム + sass.NodePackageImporter で解決。webpack.common.js 参照）
+# から読み込む。以前は ablogcms/themes/system への相対パスで参照していたため、302xリポジトリ内の
+# ローカル symlink 無しではビルドが成立しなかった問題を修正済み（#61）。
 
 on:
   pull_request:
   push:
     branches:
-      - develop/v3
-      - release/v3
+      - 'develop/**'
+      - 'release/**'
       - 'feature/**'
       - 'fix/**'
 
@@ -32,6 +32,9 @@ jobs:
 
       - name: Install dependencies (root, site, beginner)
         run: npm ci
+
+      - name: Build themes (site, beginner)
+        run: npm run build:themes
 
       - name: Build release package
         run: npm run package


### PR DESCRIPTION
## 概要

1. `test.yml` の `build:themes`（webpack build）ステップを復活させた。#61（`@ablogcms/acms.css` 移行）で `themes/system` への相対参照問題が解消済みのため、以前このステップを削除した理由（`ablogcms/themes/system` への相対パス参照が302xリポジトリ外では解決できず構造的にビルド失敗する）が無くなっている。古いコメントも合わせて更新。
2. `test.yml` の `push` トリガー対象ブランチを `develop/v3` / `release/v3` から `develop/**` / `release/**` に変更。v4系列（`develop/v4`, `release/v4` 等）が作られた際もこのファイルを変更せずに動作するようにした。
3. `dependabot.yml` の `target-branch` はワイルドカード非対応（Dependabotの仕様上、実ブランチ名を1つ明示する必要がある）ため汎用化できないことをコメントで明記。v4系列を開始する際は4箇所の `target-branch` を `develop/v4` に書き換える必要がある。

## 動作確認

ローカルで `npm ci` → `npm run build:themes`（site・beginner ともに webpack compiled successfully）→ `npm run package` の一連の手順が成功することを確認済み。

## 補足

リポジトリ設定側の Ruleset（`develop branch` / `release branch` 相当）は既に `develop/**/*` / `release/**/*` のパターンで汎用化・Test必須設定済みのため、このPRでは対応不要。