### PR TITLE
site/beginnerの@ablogcms/acms.css依存を3.2.32へ更新

### DIFF
--- a/themes/beginner/package-lock.json
+++ b/themes/beginner/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.12",
       "license": "MIT",
       "devDependencies": {
-        "@ablogcms/acms.css": "^3.2.29",
+        "@ablogcms/acms.css": "^3.2.32",
         "autoprefixer": "^10.5.4",
         "browserslist": "^4.28.1",
         "css-loader": "^7.1.4",
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@ablogcms/acms.css": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@ablogcms/acms.css/-/acms.css-3.2.29.tgz",
-      "integrity": "sha512-gpExOmvIucX9OqXzs5ZoP5pDG/PwqRzhY1eXI8NPVNjwfUPOlEf8xF7k2yCb6isGQUjU3cS9Cmd50xa3blfl1g==",
+      "version": "3.2.32",
+      "resolved": "https://registry.npmjs.org/@ablogcms/acms.css/-/acms.css-3.2.32.tgz",
+      "integrity": "sha512-ODD4yeEydWLkzq6MLyz+4O8LLPcIAnXuF01LNDNd5ojBQ8mt+JSB04mo4vb7qrJMoVQZY0S57zkJPFLq3rJEsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6674,9 +6674,9 @@
   },
   "dependencies": {
     "@ablogcms/acms.css": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@ablogcms/acms.css/-/acms.css-3.2.29.tgz",
-      "integrity": "sha512-gpExOmvIucX9OqXzs5ZoP5pDG/PwqRzhY1eXI8NPVNjwfUPOlEf8xF7k2yCb6isGQUjU3cS9Cmd50xa3blfl1g==",
+      "version": "3.2.32",
+      "resolved": "https://registry.npmjs.org/@ablogcms/acms.css/-/acms.css-3.2.32.tgz",
+      "integrity": "sha512-ODD4yeEydWLkzq6MLyz+4O8LLPcIAnXuF01LNDNd5ojBQ8mt+JSB04mo4vb7qrJMoVQZY0S57zkJPFLq3rJEsg==",
       "dev": true,
       "requires": {
         "normalize.css": "^8.0.1",

--- a/themes/beginner/package.json
+++ b/themes/beginner/package.json
@@ -25,7 +25,7 @@
   "author": "appleple",
   "license": "MIT",
   "devDependencies": {
-    "@ablogcms/acms.css": "^3.2.29",
+    "@ablogcms/acms.css": "^3.2.32",
     "autoprefixer": "^10.5.4",
     "browserslist": "^4.28.1",
     "css-loader": "^7.1.4",

--- a/themes/site/package-lock.json
+++ b/themes/site/package-lock.json
@@ -12,7 +12,7 @@
         "dom-content-loaded": "^1.0.2"
       },
       "devDependencies": {
-        "@ablogcms/acms.css": "^3.2.29",
+        "@ablogcms/acms.css": "^3.2.32",
         "@babel/core": "^8.0.1",
         "@babel/preset-env": "^8.0.2",
         "@eslint/js": "^10.0.1",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@ablogcms/acms.css": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@ablogcms/acms.css/-/acms.css-3.2.29.tgz",
-      "integrity": "sha512-gpExOmvIucX9OqXzs5ZoP5pDG/PwqRzhY1eXI8NPVNjwfUPOlEf8xF7k2yCb6isGQUjU3cS9Cmd50xa3blfl1g==",
+      "version": "3.2.32",
+      "resolved": "https://registry.npmjs.org/@ablogcms/acms.css/-/acms.css-3.2.32.tgz",
+      "integrity": "sha512-ODD4yeEydWLkzq6MLyz+4O8LLPcIAnXuF01LNDNd5ojBQ8mt+JSB04mo4vb7qrJMoVQZY0S57zkJPFLq3rJEsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/themes/site/package.json
+++ b/themes/site/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@babel/core": "^8.0.1",
     "@babel/preset-env": "^8.0.2",
-    "@ablogcms/acms.css": "^3.2.29",
+    "@ablogcms/acms.css": "^3.2.32",
     "@eslint/js": "^10.0.1",
     "autoprefixer": "^10.5.4",
     "babel-loader": "^10.1.1",


### PR DESCRIPTION
## 概要
- @ablogcms/acms.css 3.2.32 リリースに伴い、site/beginner の devDependencies を `^3.2.29` から `^3.2.32` へ更新
- package-lock.json も再生成

## 関連
- CMS-7870 (a-blog cms本体側の対応チケット)